### PR TITLE
Makefile ergänzen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+SOURCEFILE=pythonTutorial
+THELATEX=pdflatex
+
+.PHONY: all clean
+
+all: 
+	pdflatex $(SOURCEFILE).tex
+	bibtex $(SOURCEFILE)
+	pdflatex $(SOURCEFILE).tex
+	pdflatex $(SOURCEFILE).tex
+
+clean:
+	rm -vf $(SOURCEFILE).{aux,bbl,bcf,blg,log,out,run.xml,toc,acn,glo,idx,ist,lot,syg,acr,alg,glg,gls,slg,syi,pyg,lol,lof,tdo}


### PR DESCRIPTION
Das makefile sollte auf jedem Linux/Unix System und auf der git-bash und dem Ubuntu-Subsystem von Windows laufen. Nimmt einem die Arbeit ab, die Befehle immer von Hand einzutippen. Das Target `all` erzeugt das pdf (und ist default, wenn man nur `make` eintippt) und das Target `clean` entfernt die Hilfsdateien. Je nachdem warum das Projekt vielleicht mal nicht kompiliert, kann auch das hilfreich sein.